### PR TITLE
Fix marshaling objects with null values

### DIFF
--- a/src/cbor.js
+++ b/src/cbor.js
@@ -17,6 +17,7 @@ exports.marshal = (original) => {
   const input = cloneDeep(original)
 
   function transform (obj) {
+    if (obj == null) return obj
     const keys = Object.keys(obj)
 
     // Recursive transform

--- a/test/cbor.spec.js
+++ b/test/cbor.spec.js
@@ -124,6 +124,24 @@ describe('IPLD -> CBOR', () => {
       l1: {'/': 'hello'}
     })
   })
+
+  it('marshals objects with null values', () => {
+    const src = {
+      l1: {'/': 'hello'},
+      foo: null
+    }
+
+    const expected = {
+      l1: new cbor.Tagged(ipld.LINK_TAG, 'hello'),
+      foo: null
+    }
+
+    expect(
+      ipld.marshal(src)
+    ).to.be.eql(
+      cbor.encode(expected)
+    )
+  })
 })
 
 describe('CBOR -> IPLD', () => {


### PR DESCRIPTION
This adds a null check to the inner `transform` function in `cbor.marshal`.

closes #22