### PR TITLE
feat: switch to borc

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   "homepage": "https://github.com/ipld/js-ipld-dag-cbor",
   "dependencies": {
     "async": "^2.1.4",
+    "borc": "^2.0.0",
     "bs58": "^3.1.0",
-    "cbor": "^3.0.0",
     "cids": "^0.2.0",
     "multihashes": "^0.3.0",
     "multihashing-async": "^0.3.0",

--- a/src/util.js
+++ b/src/util.js
@@ -1,9 +1,10 @@
 'use strict'
 
-const cbor = require('cbor')
+const cbor = require('borc')
 const multihashing = require('multihashing-async')
 const CID = require('cids')
 const waterfall = require('async/waterfall')
+const setImmediate = require('async/setImmediate')
 
 const resolver = require('./resolver')
 
@@ -15,13 +16,28 @@ exports.serialize = (dagNode, callback) => {
     serialized = cbor.encode(dagNode)
   } catch (err) {
     // return is important, otherwise in case of error the execution would continue
-    return callback(err)
+    return setImmediate(() => {
+      callback(err)
+    })
   }
-  callback(null, serialized)
+  setImmediate(() => {
+    callback(null, serialized)
+  })
 }
 
 exports.deserialize = (data, callback) => {
-  cbor.decodeFirst(data, callback)
+  let res
+  try {
+    res = cbor.decodeFirst(data)
+  } catch (err) {
+    return setImmediate(() => {
+      callback(err)
+    })
+  }
+
+  setImmediate(() => {
+    callback(null, res)
+  })
 }
 
 exports.cid = (dagNode, callback) => {

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -105,10 +105,6 @@ describe('IPLD format resolver (local)', () => {
           path: 'name',
           value: 'I am a node'
         }, {
-        // TODO: confirm how to represent links in tree
-          path: 'someLink//',
-          value: 'LINK'
-        }, {
           path: 'nest/foo/bar',
           value: 'baz'
         }, {
@@ -117,6 +113,10 @@ describe('IPLD format resolver (local)', () => {
         }, {
           path: 'array/1',
           value: 2
+        }, {
+          // TODO: confirm how to represent links in tree
+          path: 'someLink//',
+          value: 'LINK'
         }])
         done()
       })


### PR DESCRIPTION
This makes cbor encoding and decoding a lot faster.

Fixes #23 

cc @parkan @diasdavid 

Latest benchmarks on node 7.2.1

```
encode - node-cbor - 74 x 312 ops/sec ±5.13% (52 runs sampled)
encode - borc - 74 x 9,572 ops/sec ±2.85% (88 runs sampled)

decode - node-cbor - 45 x 260 ops/sec ±7.55% (52 runs sampled)
decode - borc - 45 x 8,485 ops/sec ±6.81% (72 runs sampled)
```