### PR TITLE
fixed bug that prevented stings from being encoded

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -34,7 +34,13 @@ const decoder = new cbor.Decoder({
 })
 
 function replaceCIDbyTAG (dagNode) {
-  if (isCircular(dagNode)) {
+  let circular
+  try {
+    circular = isCircular(dagNode)
+  } catch (e) {
+    circular = false
+  }
+  if (circular) {
     throw new Error('The object passed has circular references')
   }
 

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -62,6 +62,16 @@ describe('util', () => {
     })
   })
 
+  it('strings', (done) => {
+    dagCBOR.util.cid('some test string', (err, cid) => {
+      expect(err).to.not.exist()
+      expect(cid.version).to.equal(1)
+      expect(cid.codec).to.equal('dag-cbor')
+      expect(cid.multihash).to.exist()
+      done()
+    })
+  })
+
   it.skip('serialize and deserialize - garbage', (done) => {
     const inputs = []
 


### PR DESCRIPTION
isCurcirlar only check json objects and throws it what is being tested is not an object. but CBOR should be able to encode all of json, numbers, strings, arrays and objects.