### PR TITLE
Add hash algorithm option for cid

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -108,10 +108,10 @@ exports.deserialize = (data, callback) => {
   setImmediate(() => callback(null, deserialized))
 }
 
-exports.cid = (dagNode, callback) => {
+exports.cid = (dagNode, hashAlg, callback) => {
   waterfall([
     (cb) => exports.serialize(dagNode, cb),
-    (serialized, cb) => multihashing(serialized, 'sha2-256', cb),
+    (serialized, cb) => multihashing(serialized, hashAlg, cb),
     (mh, cb) => cb(null, new CID(1, resolver.multicodec, mh))
   ], callback)
 }

--- a/test/interop.spec.js
+++ b/test/interop.spec.js
@@ -49,7 +49,7 @@ describe('dag-cbor interop tests', () => {
         // put it back to bytes
         node[0]['/'] = bs58.decode(arrayLinkJSON[0]['/'])
 
-        dagCBOR.util.cid(node, (err, cid) => {
+        dagCBOR.util.cid(node, 'sha2-256', (err, cid) => {
           expect(err).to.not.exist()
           const cidStr = cid.toBaseEncodedString()
           expect(cidStr).to.eql(expectedCIDs['array-link']['/'])
@@ -63,7 +63,7 @@ describe('dag-cbor interop tests', () => {
         expect(err).to.not.exist()
         expect(node).to.eql(emptyArrayJSON)
 
-        dagCBOR.util.cid(node, (err, cid) => {
+        dagCBOR.util.cid(node, 'sha2-256', (err, cid) => {
           expect(err).to.not.exist()
           const cidStr = cid.toBaseEncodedString()
           expect(cidStr).to.eql(expectedCIDs['empty-array']['/'])
@@ -77,7 +77,7 @@ describe('dag-cbor interop tests', () => {
         expect(err).to.not.exist()
         expect(node).to.eql(emptyObjJSON)
 
-        dagCBOR.util.cid(node, (err, cid) => {
+        dagCBOR.util.cid(node, 'sha2-256', (err, cid) => {
           expect(err).to.not.exist()
           const cidStr = cid.toBaseEncodedString()
           expect(cidStr).to.eql(expectedCIDs['empty-obj']['/'])
@@ -91,7 +91,7 @@ describe('dag-cbor interop tests', () => {
         expect(err).to.not.exist()
         expect(node).to.eql(fooJSON)
 
-        dagCBOR.util.cid(node, (err, cid) => {
+        dagCBOR.util.cid(node, 'sha2-256', (err, cid) => {
           expect(err).to.not.exist()
           const cidStr = cid.toBaseEncodedString()
           expect(cidStr).to.eql(expectedCIDs['foo']['/'])
@@ -105,7 +105,7 @@ describe('dag-cbor interop tests', () => {
         expect(err).to.not.exist()
         expect(node).to.eql(objNoLinkJSON)
 
-        dagCBOR.util.cid(node, (err, cid) => {
+        dagCBOR.util.cid(node, 'sha2-256', (err, cid) => {
           expect(err).to.not.exist()
           const cidStr = cid.toBaseEncodedString()
           expect(cidStr).to.eql(expectedCIDs['obj-no-link']['/'])
@@ -120,7 +120,7 @@ describe('dag-cbor interop tests', () => {
       dagCBOR.util.deserialize(objWithLinkCBOR, (err, node) => {
         expect(err).to.not.exist()
 
-        dagCBOR.util.cid(node, (err, cid) => {
+        dagCBOR.util.cid(node, 'sha2-256', (err, cid) => {
           expect(err).to.not.exist()
           const cidStr = cid.toBaseEncodedString()
           expect(cidStr).to.eql(expectedCIDs['obj-with-link']['/'])

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -3,6 +3,7 @@
 
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
+const multihash = require('multihashes')
 const expect = chai.expect
 chai.use(dirtyChai)
 const garbage = require('garbage')
@@ -53,21 +54,21 @@ describe('util', () => {
   })
 
   it('.cid', (done) => {
-    dagCBOR.util.cid(obj, (err, cid) => {
+    dagCBOR.util.cid(obj, 'sha2-256', (err, cid) => {
       expect(err).to.not.exist()
       expect(cid.version).to.equal(1)
       expect(cid.codec).to.equal('dag-cbor')
-      expect(cid.multihash).to.exist()
+      expect(multihash.decode(cid.multihash).name).to.equal('sha2-256')
       done()
     })
   })
 
-  it('strings', (done) => {
-    dagCBOR.util.cid('some test string', (err, cid) => {
+  it.only('strings', (done) => {
+    dagCBOR.util.cid('some test string', 'sha2-256', (err, cid) => {
       expect(err).to.not.exist()
       expect(cid.version).to.equal(1)
       expect(cid.codec).to.equal('dag-cbor')
-      expect(cid.multihash).to.exist()
+      expect(multihash.decode(cid.multihash).name).to.equal('sha2-256')
       done()
     })
   })


### PR DESCRIPTION
This is actually in relation to changing https://github.com/ipld/js-ipld/issues/82 , where the ipfs resolver put interface needs to pass through the hashAlg to the various ipld resolver utils. This will be a breaking change as the the interface would change from (dagNode,callback) to (dagNode, hashAlg, callback) . If this change makes since, then I'll also patch up the other ipld packages. @diasdavid  