### PR TITLE
fix: pass serialized blob to util.cid

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const assert = require('assert')
 const cbor = require('borc')
 const multihashing = require('multihashing-async')
 const CID = require('cids')
@@ -116,14 +117,15 @@ exports.deserialize = (data, callback) => {
 /**
  * Get the CID of the DAG-Node.
  *
- * @param {Object} dagNode - Internal representation
+ * @param {Buffer} blob - Output from serialize()
  * @param {Object} [options] - Options to create the CID
  * @param {number} [options.version=1] - CID version number
  * @param {string} [options.hashAlg] - Defaults to hashAlg for the resolver
  * @param {CidCallback} callback - Callback that handles the return value
  * @returns {void}
  */
-exports.cid = (dagNode, options, callback) => {
+exports.cid = (blob, options, callback) => {
+  assert(Buffer.isBuffer(blob), 'blob must be a Buffer')
   if (typeof options === 'function') {
     callback = options
     options = {}
@@ -132,8 +134,7 @@ exports.cid = (dagNode, options, callback) => {
   const hashAlg = options.hashAlg || resolver.defaultHashAlg
   const version = typeof options.version === 'undefined' ? 1 : options.version
   waterfall([
-    (cb) => exports.serialize(dagNode, cb),
-    (serialized, cb) => multihashing(serialized, hashAlg, cb),
+    (cb) => multihashing(blob, hashAlg, cb),
     (mh, cb) => cb(null, new CID(version, resolver.multicodec, mh))
   ], callback)
 }

--- a/test/interop.spec.js
+++ b/test/interop.spec.js
@@ -49,7 +49,7 @@ describe('dag-cbor interop tests', () => {
         // put it back to bytes
         node[0]['/'] = bs58.decode(arrayLinkJSON[0]['/'])
 
-        dagCBOR.util.cid(node, (err, cid) => {
+        dagCBOR.util.cid(arrayLinkCBOR, (err, cid) => {
           expect(err).to.not.exist()
           const cidStr = cid.toBaseEncodedString()
           expect(cidStr).to.eql(expectedCIDs['array-link']['/'])
@@ -63,7 +63,7 @@ describe('dag-cbor interop tests', () => {
         expect(err).to.not.exist()
         expect(node).to.eql(emptyArrayJSON)
 
-        dagCBOR.util.cid(node, (err, cid) => {
+        dagCBOR.util.cid(emptyArrayCBOR, (err, cid) => {
           expect(err).to.not.exist()
           const cidStr = cid.toBaseEncodedString()
           expect(cidStr).to.eql(expectedCIDs['empty-array']['/'])
@@ -77,7 +77,7 @@ describe('dag-cbor interop tests', () => {
         expect(err).to.not.exist()
         expect(node).to.eql(emptyObjJSON)
 
-        dagCBOR.util.cid(node, (err, cid) => {
+        dagCBOR.util.cid(emptyObjCBOR, (err, cid) => {
           expect(err).to.not.exist()
           const cidStr = cid.toBaseEncodedString()
           expect(cidStr).to.eql(expectedCIDs['empty-obj']['/'])
@@ -105,7 +105,7 @@ describe('dag-cbor interop tests', () => {
         expect(err).to.not.exist()
         expect(node).to.eql(objNoLinkJSON)
 
-        dagCBOR.util.cid(node, (err, cid) => {
+        dagCBOR.util.cid(objNoLinkCBOR, (err, cid) => {
           expect(err).to.not.exist()
           const cidStr = cid.toBaseEncodedString()
           expect(cidStr).to.eql(expectedCIDs['obj-no-link']['/'])
@@ -120,7 +120,7 @@ describe('dag-cbor interop tests', () => {
       dagCBOR.util.deserialize(objWithLinkCBOR, (err, node) => {
         expect(err).to.not.exist()
 
-        dagCBOR.util.cid(node, (err, cid) => {
+        dagCBOR.util.cid(objWithLinkCBOR, (err, cid) => {
           expect(err).to.not.exist()
           const cidStr = cid.toBaseEncodedString()
           expect(cidStr).to.eql(expectedCIDs['obj-with-link']['/'])

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -54,36 +54,32 @@ describe('util', () => {
   })
 
   it('.cid', (done) => {
-    dagCBOR.util.cid(obj, (err, cid) => {
+    dagCBOR.util.serialize(obj, (err, serialized) => {
       expect(err).to.not.exist()
-      expect(cid.version).to.equal(1)
-      expect(cid.codec).to.equal('dag-cbor')
-      expect(cid.multihash).to.exist()
-      const mh = multihash.decode(cid.multihash)
-      expect(mh.name).to.equal('sha2-256')
-      done()
+      dagCBOR.util.cid(serialized, (err, cid) => {
+        expect(err).to.not.exist()
+        expect(cid.version).to.equal(1)
+        expect(cid.codec).to.equal('dag-cbor')
+        expect(cid.multihash).to.exist()
+        const mh = multihash.decode(cid.multihash)
+        expect(mh.name).to.equal('sha2-256')
+        done()
+      })
     })
   })
 
   it('.cid with hashAlg', (done) => {
-    dagCBOR.util.cid(obj, { hashAlg: 'sha2-512' }, (err, cid) => {
+    dagCBOR.util.serialize(obj, (err, serialized) => {
       expect(err).to.not.exist()
-      expect(cid.version).to.equal(1)
-      expect(cid.codec).to.equal('dag-cbor')
-      expect(cid.multihash).to.exist()
-      const mh = multihash.decode(cid.multihash)
-      expect(mh.name).to.equal('sha2-512')
-      done()
-    })
-  })
-
-  it('strings', (done) => {
-    dagCBOR.util.cid('some test string', (err, cid) => {
-      expect(err).to.not.exist()
-      expect(cid.version).to.equal(1)
-      expect(cid.codec).to.equal('dag-cbor')
-      expect(cid.multihash).to.exist()
-      done()
+      dagCBOR.util.cid(serialized, { hashAlg: 'sha2-512' }, (err, cid) => {
+        expect(err).to.not.exist()
+        expect(cid.version).to.equal(1)
+        expect(cid.codec).to.equal('dag-cbor')
+        expect(cid.multihash).to.exist()
+        const mh = multihash.decode(cid.multihash)
+        expect(mh.name).to.equal('sha2-512')
+        done()
+      })
     })
   })
 


### PR DESCRIPTION
BREAKING CHANGE: the first argument is now the serialized output NOT the dag node.
See https://github.com/ipld/interface-ipld-format/issues/32