### PR TITLE
Increase the size of the decoder buffer to 1meg.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -30,7 +30,8 @@ const decoder = new cbor.Decoder({
       val = val.slice(1)
       return {'/': val}
     }
-  }
+  },
+  size: 1e+6 /* one megabyte */
 })
 
 function replaceCIDbyTAG (dagNode) {


### PR DESCRIPTION
The current default is far too small, it's breaking on a node I have that is only 66015 bytes.