### PR TITLE
docs: edit for clarity/consistency in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const file = {
 dagCBOR.util.serialize(file, (err, serialized) => {})
 
 
-ipld.util.deserialize(serialize, (err, node) => {
+dagCBOR.util.deserialize(serialized, (err, node) => {
   if (err) {
     throw err
   }


### PR DESCRIPTION
The deserialize example used `ipld` as the name of the js-ipld-dag-cbor object, while the serialize example used `dagCBOR`. I changed them both to `dagCBOR` for consistency.