### PR TITLE
BREAKING CHANGE: Serialize and de-serialize links to CID instances. 

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -2,6 +2,7 @@
 
 const util = require('./util')
 const traverse = require('traverse')
+const CID = require('cids')
 
 exports = module.exports
 
@@ -80,7 +81,7 @@ function flattenObject (obj, delimiter) {
   }
 
   return traverse(obj).reduce(function (acc, x) {
-    if (typeof x === 'object' && x['/']) {
+    if (CID.isCID(x)) {
       this.update(undefined)
     }
     const path = this.path.join(delimiter)
@@ -125,7 +126,7 @@ exports.isLink = (binaryBlob, path, callback) => {
       return callback(new Error('path out of scope'))
     }
 
-    if (typeof result.value === 'object' && result.value['/']) {
+    if (CID.isCID(result.value)) {
       callback(null, result.value)
     } else {
       callback(null, false)

--- a/src/util.js
+++ b/src/util.js
@@ -15,6 +15,8 @@ const CID_CBOR_TAG = 42
 function tagCID (cid) {
   if (typeof cid === 'string') {
     cid = new CID(cid).buffer
+  } else if (CID.isCID(cid)) {
+    cid = cid.buffer
   }
 
   return new cbor.Tagged(CID_CBOR_TAG, Buffer.concat([
@@ -28,7 +30,7 @@ const decoder = new cbor.Decoder({
     [CID_CBOR_TAG]: (val) => {
       // remove that 0
       val = val.slice(1)
-      return {'/': val}
+      return new CID(val)
     }
   }
 })
@@ -53,9 +55,12 @@ function replaceCIDbyTAG (dagNode) {
       return obj.map(transform)
     }
 
+    if (CID.isCID(obj)) {
+      return tagCID(obj)
+    }
+
     const keys = Object.keys(obj)
 
-    // only `{'/': 'link'}` are valid
     if (keys.length === 1 && keys[0] === '/') {
       // Multiaddr encoding
       // if (typeof link === 'string' && isMultiaddr(link)) {

--- a/test/interop.spec.js
+++ b/test/interop.spec.js
@@ -11,9 +11,11 @@ const dagCBOR = require('../src')
 const loadFixture = require('aegir/fixtures')
 const bs58 = require('bs58')
 const isNode = require('detect-node')
+const CID = require('cids')
 
 const arrayLinkCBOR = loadFixture('test/fixtures/array-link.cbor')
 const arrayLinkJSON = require('./fixtures/array-link.json')
+const arrayLink = arrayLinkJSON.map(x => new CID(x['/']))
 
 const emptyArrayCBOR = loadFixture('test/fixtures/empty-array.cbor')
 const emptyArrayJSON = require('./fixtures/empty-array.json')
@@ -41,13 +43,9 @@ describe('dag-cbor interop tests', () => {
       dagCBOR.util.deserialize(arrayLinkCBOR, (err, node) => {
         expect(err).to.not.exist()
         // the JSON version that gets out of go-ipfs stringifies the CID
-        const bs58Str = bs58.encode(node[0]['/'])
+        const bs58Str = node[0].toBaseEncodedString()
 
-        node[0]['/'] = bs58Str
-        expect(node).to.eql(arrayLinkJSON)
-
-        // put it back to bytes
-        node[0]['/'] = bs58.decode(arrayLinkJSON[0]['/'])
+        expect(bs58Str).to.eql(arrayLink[0].toBaseEncodedString())
 
         dagCBOR.util.cid(node, (err, cid) => {
           expect(err).to.not.exist()
@@ -94,7 +92,7 @@ describe('dag-cbor interop tests', () => {
         dagCBOR.util.cid(node, (err, cid) => {
           expect(err).to.not.exist()
           const cidStr = cid.toBaseEncodedString()
-          expect(cidStr).to.eql(expectedCIDs['foo']['/'])
+          expect(cidStr).to.eql(expectedCIDs.foo['/'])
           done()
         })
       })

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -101,8 +101,7 @@ describe('IPLD format resolver (local)', () => {
     it('resolver.isLink with valid Link', (done) => {
       resolver.isLink(nodeBlob, 'someLink', (err, link) => {
         expect(err).to.not.exist()
-        const linkCID = new CID(link['/'])
-        expect(CID.isCID(linkCID)).to.equal(true)
+        expect(CID.isCID(link)).to.equal(true)
         done()
       })
     })
@@ -135,9 +134,7 @@ describe('IPLD format resolver (local)', () => {
       it('path out of scope', (done) => {
         resolver.resolve(nodeBlob, 'someLink/a/b/c', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql({
-            '/': new CID('QmaNh5d3hFiqJAGjHmvxihSnWDGqYZCn7H2XHpbttYjCNE').buffer
-          })
+          expect(result.value).to.eql(new CID('QmaNh5d3hFiqJAGjHmvxihSnWDGqYZCn7H2XHpbttYjCNE'))
           expect(result.remainderPath).to.equal('a/b/c')
           done()
         })

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -9,18 +9,19 @@ const garbage = require('garbage')
 const map = require('async/map')
 const dagCBOR = require('../src')
 const multihash = require('multihashes')
+const CID = require('cids')
 
 describe('util', () => {
   const obj = {
     someKey: 'someValue',
-    link: { '/': Buffer.from('aaaaa') },
+    link: new CID('QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL'),
     links: [
-      { '/': Buffer.from('1a') },
-      { '/': Buffer.from('2b') }
+      new CID('QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL'),
+      new CID('QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL')
     ],
     nested: {
       hello: 'world',
-      link: { '/': Buffer.from('mylink') }
+      link: new CID('QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL')
     }
   }
 


### PR DESCRIPTION
As discussed in https://github.com/ipld/ipld/issues/44 and maybe even a few other places, the current API for links is very verbose. In order to do anything with the links we end up converting them to CID's anyway so why not just serialize/deserialize them to CIDs automatically?

This saves use some conversations and makes the serialize/deserialize functions symmetrical (before the serializer took a string but the deserializer returned a Buffer).

**Note: Browser tests are failing locally but it isn't giving me any information about which tests or why.**