### PR TITLE
feat: Support the hashLen option of multihashing

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -125,6 +125,7 @@ exports.deserialize = (data, callback) => {
  * @param {Object} [options] - Options to create the CID
  * @param {number} [options.version=1] - CID version number
  * @param {string} [options.hashAlg] - Defaults to hashAlg for the resolver
+ * @param {number} [options.hashLen] - Optionally trim the digest to this length
  * @param {CidCallback} callback - Callback that handles the return value
  * @returns {void}
  */
@@ -135,10 +136,11 @@ exports.cid = (dagNode, options, callback) => {
   }
   options = options || {}
   const hashAlg = options.hashAlg || resolver.defaultHashAlg
+  const hashLen = options.hashLen
   const version = typeof options.version === 'undefined' ? 1 : options.version
   waterfall([
     (cb) => exports.serialize(dagNode, cb),
-    (serialized, cb) => multihashing(serialized, hashAlg, cb),
+    (serialized, cb) => multihashing(serialized, hashAlg, hashLen, cb),
     (mh, cb) => cb(null, new CID(version, resolver.multicodec, mh))
   ], callback)
 }

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -74,6 +74,24 @@ describe('util', () => {
       expect(cid.multihash).to.exist()
       const mh = multihash.decode(cid.multihash)
       expect(mh.name).to.equal('sha2-512')
+      expect(mh.length).to.equal(64)
+      done()
+    })
+  })
+
+  it('.cid with hashAlg and hashLen', (done) => {
+    dagCBOR.util.cid(obj, { hashAlg: 'keccak-256', hashLen: 28 }, (err, cid) => {
+      expect(err).to.not.exist()
+      expect(cid.version).to.equal(1)
+      expect(cid.codec).to.equal('dag-cbor')
+      expect(cid.multihash).to.exist()
+      const mh = multihash.decode(cid.multihash)
+      expect(mh.name).to.equal('keccak-256')
+      expect(mh.length).to.equal(28)
+      // The CID must be 32 bytes including 4 bytes for
+      // <cid-version><multicodec><hash-function><digest-size>
+      expect(cid.buffer.length).to.equal(32)
+      expect(cid.toBaseEncodedString()).to.equal('z6dSUELEcAsg5oXs7gsv42rYfczTLizSBTpGUa5M3bxe')
       done()
     })
   })


### PR DESCRIPTION
This supports the creation CIDs of particular sizes using the variable size of multihashes. One use-case is to fit into the 32 bytes word size of Ethereum.