### PR TITLE
Make cbor Decoder configurable

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -23,16 +23,6 @@ function tagCID (cid) {
   ]))
 }
 
-const decoder = new cbor.Decoder({
-  tags: {
-    [CID_CBOR_TAG]: (val) => {
-      // remove that 0
-      val = val.slice(1)
-      return new CID(val)
-    }
-  }
-})
-
 function replaceCIDbyTAG (dagNode) {
   let circular
   try {
@@ -86,6 +76,24 @@ function replaceCIDbyTAG (dagNode) {
 }
 
 exports = module.exports
+
+let decoder = null
+
+exports.configureDecoder = (opts) => {
+  opts = opts || {}
+  decoder = new cbor.Decoder({
+    tags: Object.assign({
+      [CID_CBOR_TAG]: (val) => {
+        // remove that 0
+        val = val.slice(1)
+        return new CID(val)
+      }
+    }, opts.tags || {}),
+    size: opts.size
+  })
+}
+
+exports.configureDecoder() // Setup default cbor.Decoder
 
 exports.serialize = (dagNode, callback) => {
   let serialized

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -44,6 +44,27 @@ describe('util', () => {
     })
   })
 
+  it('.serialize and .deserialize large objects', (done) => {
+    const size = 65536 * 2
+    const largeObj = { someKey: [].slice.call(new Uint8Array(size)) }
+    // Configure decoder with custom size
+    dagCBOR.util.configureDecoder({ size: size + 1 })
+
+    dagCBOR.util.serialize(largeObj, (err, serialized) => {
+      expect(err).to.not.exist()
+      expect(Buffer.isBuffer(serialized)).to.equal(true)
+
+      dagCBOR.util.deserialize(serialized, (err, deserialized) => {
+        expect(err).to.not.exist()
+        expect(largeObj).to.eql(deserialized)
+
+        // Reset decoder back to default
+        dagCBOR.util.configureDecoder()
+        done()
+      })
+    })
+  })
+
   it('error catching', (done) => {
     const circlarObj = {}
     circlarObj.a = circlarObj


### PR DESCRIPTION
This PR is to allow the underlying `cbor.Decoder` to be configured with additional options, namely the size parameter.

Currently we are using this library to explore an ipld dag - in some cases, errors are raised due to decoding large objects. By allowing the user to configure the size here, they can determine what the size limit for their application should be.