### PR TITLE
refactor: default to CID v1 and encode with base32

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/ipld/js-ipld-dag-cbor",
   "dependencies": {
     "borc": "^2.1.0",
-    "cids": "~0.5.7",
+    "cids": "github:multiformats/js-cid#refactor/cidv1base32-default",
     "is-circular": "^1.0.2",
     "multihashing-async": "~0.5.2",
     "traverse": "~0.6.6"


### PR DESCRIPTION
BREAKING CHANGE: Any CIDs created by this module are now base32 encoded by default when stringified.

Depends on:

* [ ] https://github.com/multiformats/js-cid/pull/73