### PR TITLE
fix: typo in travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-IPLD-blue.svg?style=flat-square)](http://github.com/ipld/ipld)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
-[![Travis CI](https://flat.badgen.net/travis/ipld/js-ipld-dag-pb)](https://travis-ci.com/ipld/js-ipld-dag-pb)
+[![Travis CI](https://flat.badgen.net/travis/ipld/js-ipld-dag-cbor)](https://travis-ci.com/ipld/js-ipld-dag-cbor)
 [![Coverage](https://coveralls.io/repos/github/ipld/js-ipld-dag-cbor/badge.svg?branch=master)](https://coveralls.io/github/ipld/js-ipld-dag-cbor?branch=master)
 [![](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 [![](https://david-dm.org/ipld/js-ipld-dag-cbor.svg?style=flat-square)](https://david-dm.org/ipld/js-ipld-dag-cbor)


### PR DESCRIPTION
The Travis CI badge currently points to [`js-ipld-dag-pb`](https://travis-ci.com/ipld/js-ipld-dag-pb), not [`js-ipld-dag-cbor`](https://travis-ci.com/ipld/js-ipld-dag-cbor) :-)