### PR TITLE
Use object shorthand for properties

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -114,7 +114,7 @@ exports.configureDecoder = (options) => {
   }
 
   const decoderOptions = {
-    tags: tags,
+    tags,
     size: currentSize
   }
 


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: The source code is transpiled before publishing, so this should be good to go ✅ 