### PR TITLE
Serialize Uint8Array as binary (like Buffer)

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -35,7 +35,7 @@ function replaceCIDbyTAG (dagNode) {
   }
 
   function transform (obj) {
-    if (!obj || Buffer.isBuffer(obj) || typeof obj === 'string') {
+    if (!obj || obj instanceof Uint8Array || typeof obj === 'string') {
       return obj
     }
 

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -109,4 +109,17 @@ describe('util', () => {
       expect(decoded).to.eql(original)
     }
   })
+
+  it('.serialize and .deserialize object with Uint8Array field', () => {
+    const buffer = Buffer.from('some data')
+    const bytes = Uint8Array.from(buffer)
+
+    const s1 = dagCBOR.util.serialize({ data: buffer })
+    const s2 = dagCBOR.util.serialize({ data: bytes })
+
+    expect(s1).to.be.eql(s2)
+
+    expect(dagCBOR.util.deserialize(s1)).to.be.eql({ data: bytes })
+    expect(dagCBOR.util.deserialize(s2)).to.be.eql({ data: bytes })
+  })
 })


### PR DESCRIPTION
As per #128 this change treats `Uint8Array` just as it treats `Buffer`, which also happens to match underlying borc implementation:

https://github.com/dignifiedquire/borc/blob/master/src/encoder.js#L406-L407