### PR TITLE
add encodeCBOR check

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -49,7 +49,7 @@ function replaceCIDbyTAG (dagNode) {
     }
 
     const keys = Object.keys(obj)
-
+    
     if (keys.length > 0) {
       // Recursive transform
       const out = {}
@@ -134,6 +134,7 @@ exports.configureDecoder() // Setup default cbor.Decoder
  */
 exports.serialize = (node) => {
   const nodeTagged = replaceCIDbyTAG(node)
+  if(typeof node.encodeCBOR === 'function') nodeTagged.encodeCBOR = node.encodeCBOR
   const serialized = cbor.encode(nodeTagged)
 
   return serialized


### PR DESCRIPTION
This is  a simple if check that checks if the encodeCBOR key is a function and if yes adds it back to the object after tagging´.
So onde can have custom encoding functions as described here [borc](https://github.com/dignifiedquire/borc#encode-custom-types). Should do no further harm